### PR TITLE
Added web notifications install task

### DIFF
--- a/ansible/roles/ocp4-workload-mlops/tasks/install-web-notifications.yaml
+++ b/ansible/roles/ocp4-workload-mlops/tasks/install-web-notifications.yaml
@@ -1,0 +1,32 @@
+---
+# After the web notifications service has been deployed, it will be accessible
+# at:
+# http://webnotifications.labs-infra.svc.cluster.local:8080
+#
+# You can publish messages to it by doing:
+# curl http://webnotifications.labs-infra.svc.cluster.local:8080/api/send/Hello+World
+#
+# Or:
+# curl -XPUT -d 'Hello World' http://webnotifications.labs-infra.svc.cluster.local:8080/api/send
+
+- name: create labs-infra project
+  k8s:
+    state: present
+    kind: Project
+    api_version: project.openshift.io/v1
+    definition:
+      metadata:
+        name: "labs-infra"
+        annotations:
+          openshift.io/description: ""
+          openshift.io/display-name: "Lab Infrastructure"
+
+- name: Remove webnotifications if it exists
+  command: "oc delete all -l app=webnotifications -n labs-infra"
+  ignore_errors: yes
+
+- name: Create webnotifications deployment
+  command: "oc new-app --docker-image=quay.io/kwkoo/webnotifications --env=TZ=Asia/Singapore -n labs-infra"
+
+- name: Create route for webnotifications
+  command: "oc expose svc/webnotifications -n labs-infra"


### PR DESCRIPTION
After the web notifications service has been deployed, it will be accessible
at:
<http://webnotifications.labs-infra.svc.cluster.local:8080>

You can publish messages to it by doing:

```
curl http://webnotifications.labs-infra.svc.cluster.local:8080/api/send/Hello+World
```

Or:

```
curl -XPUT -d 'Hello World' http://webnotifications.labs-infra.svc.cluster.local:8080/api/send
```