### PR TITLE
Send pings to prevent HAProxy from closing websocket connections

### DIFF
--- a/ansible/roles/ocp4-workload-mlops/tasks/install-web-notifications.yaml
+++ b/ansible/roles/ocp4-workload-mlops/tasks/install-web-notifications.yaml
@@ -14,7 +14,7 @@
   ignore_errors: yes
 
 - name: Create webnotifications deployment
-  command: "oc new-app --docker-image=quay.io/kwkoo/webnotifications --env=TZ=Asia/Singapore -n {{ns}}"
+  command: "oc new-app --docker-image=quay.io/kwkoo/webnotifications --env=TZ=Asia/Singapore --env=PINGINTERVAL=10 -n {{ns}}"
 
 - name: Create route for webnotifications
   command: "oc expose svc/webnotifications -n {{ns}}"


### PR DESCRIPTION
HAProxy will close idle connections.

That forces web notifications users to reload their browsers to reconnect.

This change tells the web notifications servers to send regular ping messages to clients to prevent HAProxy from closing the websocket connections.